### PR TITLE
Clarify wording of 'team leads' to leading projects and initiatives.

### DIFF
--- a/Levels.md
+++ b/Levels.md
@@ -8,7 +8,6 @@ These levels are meant to exemplify Mixmax’s core values “building strength 
 
 The goal of this document is to provide clarity on how to advance in rank at Mixmax, and to help communicate what we’re looking for when we bring on new engineers at a certain level. You should be able to have a conversation with your manager about what you need to do in order to move onto the next level and formulate a specific plan to get there.
 
-
 ## Leveling Up
 
 Your overall level is an aggregation of your level across the dimensions that we focus on here at Mixmax:
@@ -23,29 +22,25 @@ This dimension focuses on the way that an engineer gets things done: planning, s
 
 ### Collaboration
 
-This dimension focuses on the way an engineer works together with teammates: communication skills, asking for and giving feedback, collaborating, sharing knowledge, unblocking others, leading teams, participating in meetings.
+This dimension focuses on the way an engineer works together with teammates: communication skills, asking for and giving feedback, collaborating, sharing knowledge, unblocking others, leading projects, and participating in meetings.
 
 ### Support
 
 This dimension focuses on how an engineer supports themselves, their teammates, all of engineering and the company as a whole. It focuses on the glue that engineers can use to help be a part of and build incredible relationships and teams. Relevant skills include living the company values, supporting other engineers, recruiting, evangelizing, and leading organizational initiatives.
-
-
-
 
 Your level in a dimension at Mixmax is determined by which of these behaviours you consistently​ and ​regularly​ apply. Writing a spec does not instantly qualify you for L2 - think of it as needing to be able to demonstrate that you’re an L2 consistently for at least 3 months before you fully qualify.
 
 As you level up, we encourage a multifaceted approach - you’ll touch base with your manager at least quarterly to discuss how to iterate on this. If you want to focus in, and hone your superpowers, awesome! If you want to spend time working on your weaknesses, 🙌. We want you to focus on what will make you, as an individual, a phenomenal engineer. Everyone has specific superpowers that need to be continually replenished and developed, and working on weaknesses will increase your ability in other areas that then act as multiplying factors for your superpowers.
 
 To reiterate this and to riff on how this ties into our values:
+
 - We all have our own superpowers, allowing us to build strength in our differences, and so it’s important to always be developing these.
 - We also need to work on our weaknesses, so that we can strengthen them to multiply the power of our superpowers, allow us to do more with less.
 - These together help us bring the best out in each other.
 - Which in turn allows us to live as one team, with one mission.
 - Which we have to do in order to turn our customers into heroes at work.
 
-
 When you have these discussions with your manager, it’s up to both of you to come up with an actionable plan on what you can do to increase your rank, along with a desired timeframe for completion.
-
 
 ### New Hires
 
@@ -62,159 +57,179 @@ An L1 engineer is often new to software development, either from school or a boo
 L1s main focus to advance should be familiarity with the codebase, technologies, and coding concepts. L1s have project level impact.
 
 #### Impact
- * As newer engineers, L1s will primarily have an impact on themselves and their tasks, and so their projects.
- 
+
+- As newer engineers, L1s will primarily have an impact on themselves and their tasks, and so their projects.
+
 #### Technical
- * Can work independently on small issues and isolated stories that are well-scoped
- * Demonstrates a basic understanding of core technologies like Express, React and
-Javascript
- * Writes well structured code and writes automated tests appropriately.
- 
+
+- Can work independently on small issues and isolated stories that are well-scoped
+- Demonstrates a basic understanding of core technologies like Express, React and
+  Javascript
+- Writes well structured code and writes automated tests appropriately.
+
 #### Execution
- * Consistently completes tasks on time and sees them through to completion
- * Works to push tickets through review, testing, etc.
- * Conducts test parties for their features when appropriate.
- * Raises issues to the team when blocked on a ticket.
+
+- Consistently completes tasks on time and sees them through to completion
+- Works to push tickets through review, testing, etc.
+- Conducts test parties for their features when appropriate.
+- Raises issues to the team when blocked on a ticket.
 
 #### Collaboration
- * Participates in team, guild, and co-working discussions.
- * Provides feedback to team members and their manager appropriately.
- * Receives feedback constructively and works to resolve issues raised.
+
+- Participates in team, guild, and co-working discussions.
+- Provides feedback to team members and their manager appropriately.
+- Receives feedback constructively and works to resolve issues raised.
 
 #### Support
- * Conducts themselves according to the Mixmax code of conduct at all times.
- * Is familiar with Mixmax values, and makes efforts to follow them.
- * Contributes to organizational initiatives, such as participating in cultural breakout
-sessions.
- * Actively looks to grow through ​their own skills through goal-setting and soliciting
-feedback​.
+
+- Conducts themselves according to the Mixmax code of conduct at all times.
+- Is familiar with Mixmax values, and makes efforts to follow them.
+- Contributes to organizational initiatives, such as participating in cultural breakout
+  sessions.
+- Actively looks to grow through ​their own skills through goal-setting and soliciting
+  feedback​.
 
 #### Expected timeframe to next level
-We expect L1s to transition to L2 within one to two years
 
+We expect L1s to transition to L2 within one to two years
 
 ### L2
 
 An L2 engineer is capable of working on a project collaboratively with other team members, including defining specifications, defining architecture and solutions to projects, and ensuring that their work in a project covers all aspects of these specifications. L2 engineers should be active participants in PR reviews, team, guild, and engineering-wide meetings, and should be able to act as mentors to L1 engineers. L2s are increasing their team-level impact through such mentorship and teamwork.
 
 #### Impact
- * An L2’s impact radius is their team.
- * They’re beginning to take responsibility for an area of our system (with guidance) and
-through taking initiative (e.g fixes bugs unprompted).
- * They help mentor L1s and inspire teamwork.
+
+- An L2’s impact radius is their team.
+- They’re beginning to take responsibility for an area of our system (with guidance) and
+  through taking initiative (e.g fixes bugs unprompted).
+- They help mentor L1s and inspire teamwork.
 
 #### Technical
- * Proposes architecture and solutions for small to mid-sized projects
- * Familiar with all core services of the Mixmax platform
- * Strong familiarity with core technologies used at Mixmax
+
+- Proposes architecture and solutions for small to mid-sized projects
+- Familiar with all core services of the Mixmax platform
+- Strong familiarity with core technologies used at Mixmax
 
 #### Execution
- * Can manage the workload of a project, including specification writing, creating an issue backlog, and executing on completion of the project.
- * Able to estimate workload and execute successfully within a weekly timeframe
- * Proactively works to unblock themselves on issues rather than relying on another team
-member.
- * Scope of work is focused on small to medium sized projects
+
+- Can manage the workload of a project, including specification writing, creating an issue backlog, and executing on completion of the project.
+- Able to estimate workload and execute successfully within a weekly timeframe
+- Proactively works to unblock themselves on issues rather than relying on another team
+  member.
+- Scope of work is focused on small to medium sized projects
 
 #### Collaboration
- * Presents new ideas and topics at guild meetings and co-working
- * Regularly reviews other engineers code and adds constructive feedback on code style,
-design issues, and potential risks.
- * Works with Mixmax members outside of engineering on problems
- * Able to work directly with customers to resolve issues when appropriate
- * Able to assess risk on major changes and PRs and minimize risk on code merges and
-deploys.
+
+- Presents new ideas and topics at guild meetings and co-working
+- Regularly reviews other engineers code and adds constructive feedback on code style,
+  design issues, and potential risks.
+- Works with Mixmax members outside of engineering on problems
+- Able to work directly with customers to resolve issues when appropriate
+- Able to assess risk on major changes and PRs and minimize risk on code merges and
+  deploys.
 
 #### Support
- * Lives our core values at Mixmax.
- * Helps support their peers and teammates by providing consistent feedback to them,
-espousing our culture of continuous feedback.
- * Assume good intent and trust their teammates.
- * Demonstrates empathy for teammates and consideration for the impact they have on
-others, e.g. reaching out if they sense something wrong.
- * Able to constructively voice concerns.
+
+- Lives our core values at Mixmax.
+- Helps support their peers and teammates by providing consistent feedback to them,
+  espousing our culture of continuous feedback.
+- Assume good intent and trust their teammates.
+- Demonstrates empathy for teammates and consideration for the impact they have on
+  others, e.g. reaching out if they sense something wrong.
+- Able to constructively voice concerns.
 
 #### Expected timeframe to next level
-We expect L2s to progress to L3 within two to three years.
 
+We expect L2s to progress to L3 within two to three years.
 
 ### L3
 
-An L3 engineer is more of a technical mentor to other engineers on the team, and may serve as a team lead on projects. L3 members should be able to coordinate the work done by a group of individuals in order to hit a project’s goal, whether they are formally leading a team or playing a key technical role on the team. L3s continue to demonstrate strong team-level impact.
+An L3 engineer is more of a technical mentor to other engineers on the team, and may serve as a lead on projects. L3 members should be able to coordinate the work done by a group of individuals in order to hit a project’s goal, whether they are formally leading a project or playing a key technical role on the team. L3s continue to demonstrate strong team-level impact.
 
 #### Impact
- * An L3’s impact radius is their team + their peers.
- * Share their experience and expertise to help others grow. They lead and coach within
-their team, where possible, and they’re trusted with team decisions.
- * Beginning to broaden their impact. They consider the effects of their work on other teams, as well as identifying and helping to resolve problems facing their team and
-others.
- * Fully takes responsibility for a service or component.
+
+- An L3’s impact radius is their team + their peers.
+- Share their experience and expertise to help others grow. They lead and coach within their team, where possible, and they’re trusted with team decisions.
+- Beginning to broaden their impact. They consider the effects of their work on other teams, as well as identifying and helping to resolve problems facing their team and others.
+- Fully takes responsibility for a service or component.
 
 #### Technical
- * Serves as a technical mentor for other Mixmax engineers through project leadership, specification definition, and teamwork.
- * Thoughtful, in-depth investigation into deep technical issues (​example​).
+
+- Serves as a technical mentor for other Mixmax engineers through project leadership, specification definition, and teamwork.
+- Thoughtful, in-depth investigation into deep technical issues (​example​).
 
 #### Execution
- * Consistently uses data in making decisions on architectural and product direction
- * Estimates risk of future work, identifying potential roadblocks and incorporating them into
-their estimates
- * Self-manages their time - capable of scheduling time for learning and other initiatives
-themselves without manager support
- * Scope of work incorporates larger multi-week projects
- * Documents the work they do and ensures information they maintain is kept up to date.
+
+- Consistently uses data in making decisions on architectural and product direction
+- Estimates risk of future work, identifying potential roadblocks and incorporating them into
+  their estimates
+- Self-manages their time - capable of scheduling time for learning and other initiatives
+  themselves without manager support
+- Scope of work incorporates larger multi-week projects
+- Documents the work they do and ensures information they maintain is kept up to date.
 
 #### Collaboration
- * Actively works to unblock others through helping with questions, offering technical mentorship and advice, and bringing out the best in other engineers.
- * Effectively leads meetings and organizes groups of engineers
- * Has a deep understanding of how customers use Mixmax, and applies that in the work
-they do.
- * Can be relied on to represent the company when talking to key customers or on sales
-calls.
+
+- Actively works to unblock others through helping with questions, offering technical mentorship and advice, and bringing out the best in other engineers.
+- Effectively leads meetings and organizes groups of engineers
+- Has a deep understanding of how customers use Mixmax, and applies that in the work
+  they do.
+- Can be relied on to represent the company when talking to key customers or on sales
+  calls.
 
 #### Support
- * Helps newer teammates live our values.
- * Gives incremental and consistent feedback to all team members.
- * Champions or owns new cultural initiatives.
- * Assists recruiting efforts in growing the Mixmax team, either through interviewing or
-other activities.
- * Writes insightful documentation and processes.
+
+- Helps newer teammates live our values.
+- Gives incremental and consistent feedback to all team members.
+- Champions or owns new cultural initiatives.
+- Assists recruiting efforts in growing the Mixmax team, either through interviewing or
+  other activities.
+- Writes insightful documentation and processes.
 
 #### Expected timeframe to next level
-If an engineer wants to focus on moving to the next level, this will typically take two+ years to grow their influence to L4.
 
+If an engineer wants to focus on moving to the next level, this will typically take two+ years to grow their influence to L4.
 
 ### L4
 
 L4 engineers are capable of defining the architecture and coordinating the moving pieces of large projects. L4 engineers should serve as mentors and leaders for the engineering organization, either through technical mentorship, leading more substantial projects that may span a quarter, or as direct managers. L4s are expanding their team-level impact by understanding the effect of their work on their team. They’re also beginning to understand and help solve problems facing their team and other teams, by beginning to identify and lead engineering initiatives within their team and the org.
 
 #### Impact
- * In addition to their team and their peers, an L4’s impact radius is their guild (routinely have initiative and domain level impact).
- * Identify and advocate for foundational work and practice improvements in their domain.
- * Leads initiatives & meetings within team and domain. Regularly leads multi-person,
-multi-week projects
- * Has a consistent record of very strong ownership for their area (e.g. figuring out on-call
-schedules, new monitoring initiatives, research initiatives to drive their areas forward).
+
+- In addition to their team and their peers, an L4’s impact radius is their guild (routinely have initiative and domain level impact).
+- Identify and advocate for foundational work and practice improvements in their domain.
+- Leads initiatives & meetings within team and domain. Regularly leads multi-person,
+  multi-week projects
+- Has a consistent record of very strong ownership for their area (e.g. figuring out on-call
+  schedules, new monitoring initiatives, research initiatives to drive their areas forward).
 
 #### Technical
- * Proposes long-term architectural directions for major projects and technical initiatives at Mixmax.
- * Participates in defining an architectural vision for an area of the application long term.
+
+- Proposes long-term architectural directions for major projects and technical initiatives at Mixmax.
+- Participates in defining an architectural vision for an area of the application long term.
+
 #### Execution
- * Can be relied on to define an execution plan for a major project, incorporating past learnings and accommodating for unforeseen issues and learnings.
- * Can work with a team to define high level, externally facing goals for projects spanning many weeks
- * Scope of work is focused on major initiatives for a quarter.
+
+- Can be relied on to define an execution plan for a major project, incorporating past learnings and accommodating for unforeseen issues and learnings.
+- Can work with a team to define high level, externally facing goals for projects spanning many weeks
+- Scope of work is focused on major initiatives for a quarter.
 
 #### Collaboration
- * Serves as a technical mentor to other team members and can add constructive feedback and guidance to other teams’ specifications and proposals.
- * Works with key stakeholders (including cross-functionally) in assessing needs for projects and ensuring they are addressed by solutions.
+
+- Serves as a technical mentor to other team members and can add constructive feedback and guidance to other teams’ specifications and proposals.
+- Works with key stakeholders (including cross-functionally) in assessing needs for projects and ensuring they are addressed by solutions.
 
 #### Support
- * Gives guidance & unblocks others on their team and area.
- * Actively works to help grow and evolve our culture.
- * Helps junior engineers find opportunities to get involved in recruiting and evangelizing
-(i.e. via presentations opportunities both inside and outside the company).
- * Routinely carves out opportunities for more junior engineers.
- * Helps others maintain resilience during periods of change.
+
+- Gives guidance & unblocks others on their team and area.
+- Actively works to help grow and evolve our culture.
+- Helps junior engineers find opportunities to get involved in recruiting and evangelizing
+  (i.e. via presentations opportunities both inside and outside the company).
+- Routinely carves out opportunities for more junior engineers.
+- Helps others maintain resilience during periods of change.
 
 #### Expected timeframe to next level
+
 Things start to get fuzzier here, and we’d often expect this process, if desired by the engineer, to take two+ years to grow their influence to L5.
 
 ### L5
@@ -223,35 +238,41 @@ L5 engineers are able to manage an entire area of the Mixmax application and pro
 might be something we don’t do a lot as a company, but we anticipate this will be an increasingly key function as the company grows.
 
 #### Impact
- * An L5’s impact radius is, at minimum, the entire engineering department.
- * Thought leader for technical decisions, influencing architecture and prioritization across
-multiple teams.
- * Lead initiatives across domains, even outside their core expertise. Coordinates large &
-complex projects, including with outside partners.
+
+- An L5’s impact radius is, at minimum, the entire engineering department.
+- Thought leader for technical decisions, influencing architecture and prioritization across
+  multiple teams.
+- Lead initiatives across domains, even outside their core expertise. Coordinates large &
+  complex projects, including with outside partners.
 
 #### Technical
- * Leads the definition and execution of major technology initiatives (introducing new technology, redesigning areas of the application, etc.)
- * Has best-of-class knowledge in a particular aspect of Mixmax-deployed technology.
+
+- Leads the definition and execution of major technology initiatives (introducing new technology, redesigning areas of the application, etc.)
+- Has best-of-class knowledge in a particular aspect of Mixmax-deployed technology.
 
 #### Execution
- * Can work with key stakeholders, including the management team of Mixmax to define a technical long-term vision and execute on it.
- * Capable of managing the workload of a large team on a quarterly level and defining resourcing plans to meet those goals.
+
+- Can work with key stakeholders, including the management team of Mixmax to define a technical long-term vision and execute on it.
+- Capable of managing the workload of a large team on a quarterly level and defining resourcing plans to meet those goals.
 
 #### Collaboration
- * Implements new initiatives to improve quality and minimize risk in the Mixmax codebase.
- * Regularly serves a mentorship role to several senior engineers on the Mixmax team.
- * Works with all aspects of the business to help shape future direction.
+
+- Implements new initiatives to improve quality and minimize risk in the Mixmax codebase.
+- Regularly serves a mentorship role to several senior engineers on the Mixmax team.
+- Works with all aspects of the business to help shape future direction.
 
 #### Support
- * Routinely and consistently supports multiple teams moving forward.
- * Is a bastion of support for engineers to come to for advice, both professional and
-personal. This means that this individual is a go-to person for many engineers.
- * Helps act as a buffer for junior engineers, routinely reaching out to support them
-however they can.
- * Trusted to de-escalate conflicts and build consensus between team members.
- * Actively spreads the Mixmax brand to prospective candidates.
+
+- Routinely and consistently supports multiple teams moving forward.
+- Is a bastion of support for engineers to come to for advice, both professional and
+  personal. This means that this individual is a go-to person for many engineers.
+- Helps act as a buffer for junior engineers, routinely reaching out to support them
+  however they can.
+- Trusted to de-escalate conflicts and build consensus between team members.
+- Actively spreads the Mixmax brand to prospective candidates.
 
 #### Expected timeframe to next level
+
 The air is starting to get thin up here, this will often take three+ years to grow into an L6 (if the engineer decides to grow their influence more).
 
 ### L6


### PR DESCRIPTION
With managers more closely aligned with teams, the lead role is evolving to one where leads are responsible for the leadership of projects and initiatives rather than the team itself. This modifies any reference in levelling regarding 'team leads' to focus more on project leadership.

The majority of the levelling doc already spoke in terms of project leadership vs. team leadership, but there were a couple of places that made reference to team leadership.